### PR TITLE
Fixed unfinished pattern swallowing bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/lib/emo-parser.js
+++ b/lib/emo-parser.js
@@ -258,10 +258,15 @@
                     matched = true;
                     current_node = child;
                     if(child.code && (/\s/.test(next_char))) {
+                        // remove the parts of the matched emoji from matched_chars
+                        matched_chars.splice(matched_chars.length - child.value.length + 2, matched_chars.length);
+                        // print the matched chars that didn't complete a pattern
+                        result += matched_chars.join('');
+                        matched_chars = [];
+                        
                         result += ' ' + self.printEmoId(child.code, 'html');
                         // its a match
                         found = true;
-                        matched_chars = [];
                     }
                     break;
                 }
@@ -283,6 +288,11 @@
                     result += _char;
                 }
             }
+        }
+        // put back the remaining matched items form the last failed pattern
+        if(matched_chars.length) {
+            result += matched_chars.join('');
+            matched_chars = [];
         }
         return result.trim();
     };


### PR DESCRIPTION
Before this fix for some inputs a part of the input was swallowed: it just disappeared from the output without rendering the same character or an emoji.
Examples:
:
<
< : : : > : : <   (this is rendered: < : : : >)